### PR TITLE
[feat] Login페이지 아이디, 비밀번호 찾기 UI 구현

### DIFF
--- a/src/pages/Login/FindIDModal.css
+++ b/src/pages/Login/FindIDModal.css
@@ -1,0 +1,131 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  backdrop-filter: blur(5px); /* 흐림 효과 */
+}
+
+.modal {
+  background-color: white;
+  border: solid 8px var(--color-gray);
+  text-align: center;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+  min-width: 500px;
+}
+
+section > input {
+  width: 145px;
+  height: 25px;
+  background-color: var(--color-gray);
+  border: none;
+  outline: none;
+}
+
+.modal_header {
+  background-color: var(--color-navy);
+  height: 50px;
+  width: 100%;
+}
+
+.close_btn {
+  float: right;
+  margin: 7px;
+  width: 20px;
+  border: none;
+  background-color: var(--color-gray);
+  cursor: pointer;
+}
+
+.modal_body {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-top: 20px;
+  margin-bottom: 90px;
+}
+
+.find_btn {
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  padding-top: 1px;
+}
+
+.modal_body_findId,
+.modal_body_findPasswd {
+  width: 150px;
+  height: 25px;
+  border: none;
+  margin: auto 3px;
+  font-size: 17px;
+  color: var(--color-light-gray);
+}
+
+.active {
+  background-color: var(--color-navy);
+  color: white;
+}
+
+.modal_body_underLine {
+  border: 0.5px solid var(--color-navy);
+  width: 70%;
+  margin: 0 auto;
+  margin-bottom: 20px;
+  padding: 0.5px;
+  background-color: var(--color-navy);
+}
+
+.findId_content,
+.findPasswd_content {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.findId_name,
+.findId_birth {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 63%;
+  margin: 0 auto;
+  font-size: 15px;
+}
+
+.findPasswd_user_id,
+.findPasswd_user_email {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 63%;
+  margin: 0 auto;
+  font-size: 15px;
+}
+
+.modal_footer {
+  background-color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  padding-top: 10px;
+}
+
+.modal_footer > p {
+  margin: 20px;
+  font-size: 17px;
+}
+
+.modal_footer > ul {
+  text-align: left;
+  padding-left: 20px;
+  margin-bottom: 30px;
+}
+
+.modal_footer li {
+  margin-top: 3px;
+}

--- a/src/pages/Login/FindIDModal.jsx
+++ b/src/pages/Login/FindIDModal.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import "./FindIDModal.css";
+
+// /findId경로로 확인
+const FindIDModal = ({ onClose, initialMode }) => {
+  const [mode, setMode] = useState(initialMode);
+
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode]);
+
+  return (
+    <div className="overlay">
+      <div className="modal">
+        <header className="modal_header">
+          <button className="close_btn" onClick={onClose}>
+            X
+          </button>
+        </header>
+        <div className="modal_body">
+          <section className="find_btn">
+            <button
+              className={`modal_body_findId ${
+                mode === "findId" ? "active" : ""
+              }`}
+              onClick={() => setMode("findId")}
+            >
+              아이디 찾기
+            </button>
+            <button
+              className={`modal_body_findPasswd ${
+                mode === "findPasswd" ? "active" : ""
+              }`}
+              onClick={() => setMode("findPasswd")}
+            >
+              비밀번호 찾기
+            </button>
+            <hr className="modal_body_underLine"></hr>
+          </section>
+          {mode === "findId" && (
+            <div className="findId_content">
+              <section className="findId_name">
+                <label className="findId_name_user">이름</label>
+                <input type="text" />
+              </section>
+              <section className="findId_birth">
+                <label className="findId_birth_user">생년월일 6자리</label>
+                <input type="text" />
+              </section>
+            </div>
+          )}
+          {mode === "findPasswd" && (
+            <div className="findPasswd_content">
+              <section className="findPasswd_user_id">
+                <label className="user_id">아이디</label>
+                <input type="text" />
+              </section>
+              <section className="findPasswd_user_email">
+                <label className="user_email">이메일</label>
+                <input type="text" />
+              </section>
+            </div>
+          )}
+        </div>
+        <footer className="modal_footer">
+          <p>아이디 및 비밀번호 분실 문의</p>
+          <ul>
+            <li>•학 생 : 학사지원과 (031-467-0732)</li>
+            <li>•대학원생 : 대학원교학과 (031-467-0853)</li>
+            <li>•교직원 : 전산정보원 (031-467-0774)</li>
+          </ul>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default FindIDModal;

--- a/src/pages/Login/LoginPage.css
+++ b/src/pages/Login/LoginPage.css
@@ -74,7 +74,9 @@ img {
 }
 
 .login_checkbox {
-  text-align: right;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   margin-top: 25px;
   margin-bottom: 10px;
   color: #a3a3a3;
@@ -82,9 +84,9 @@ img {
 }
 
 .login_checkbox > input {
-  position: relative;
-  top: 2px;
   margin-right: 5px;
+  height: 17px;
+  width: 5%;
 }
 
 .login_button {

--- a/src/pages/Login/LoginPage.jsx
+++ b/src/pages/Login/LoginPage.jsx
@@ -2,12 +2,15 @@ import { Link } from "react-router-dom";
 import { useRef, useState } from "react";
 import Logo from "../../assets/Anyang_University_CSE_Logo.png";
 import "./LoginPage.css";
+import FindIDModal from "./FindIDModal";
 
 const LoginPage = () => {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
   const idRef = useRef(null);
   const passwordRef = useRef(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState(null);
 
   const onSubmit = () => {
     if (!id.trim()) {
@@ -27,6 +30,15 @@ const LoginPage = () => {
     if (e.key === "Enter") {
       onSubmit();
     }
+  };
+
+  const openModal = (mode) => {
+    setModalMode(mode);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
   };
 
   return (
@@ -57,16 +69,26 @@ const LoginPage = () => {
         ></input>
         <section className="login_checkbox">
           <input type="checkbox" />
-          자동 로그인
+          <p>자동 로그인</p>
         </section>
         <button className="login_button" onClick={onSubmit}>
           로그인
         </button>
         <section className="login_find">
-          <button className="login_find_id">아이디 찾기</button>
-          <button className="login_find_pw">비밀번호 찾기</button>
+          <button className="login_find_id" onClick={() => openModal("findId")}>
+            아이디 찾기
+          </button>
+          <button
+            className="login_find_pw"
+            onClick={() => openModal("findPasswd")}
+          >
+            비밀번호 찾기
+          </button>
         </section>
       </div>
+      {isModalOpen && (
+        <FindIDModal onClose={closeModal} initialMode={modalMode} />
+      )}
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,5 +3,7 @@
   --color-school: #003d9c;
   --color-green: #415636;
   --color-white: #ffffff;
-  --color-navy: #243D66;
+  --color-navy: #243d66;
+  --color-gray: #d9d9d9;
+  --color-light-gray: #a7a7a7;
 }


### PR DESCRIPTION
## 📌 변경 사항


## 로그인 파트
- 아이디 비밀번호 찾기 모달창 구현

## global CSS
- 신규 색상 추가

## 📌 테스트 방법

1. `/login` 페이지로 이동
2. 아이디 찾기 또는 비밀번호 찾기를 눌러 테스트

## 📌 영향 범위

- 로그인 페이지 (`/login`)

## 📌 추가 작업 필요 여부
- API 연동
- 로그인 유지 기능 추가 (새로고침 시 자동 로그인) => localStorage로 관리 예정
- 정상적으로 로그인되며 홈 화면(`/home`)으로 이동 지정